### PR TITLE
fix: rename opcode 0x44 from DIFFICULTY to PREVRANDAO in playground editor post-merge

### DIFF
--- a/context/ethereumContext.tsx
+++ b/context/ethereumContext.tsx
@@ -252,6 +252,14 @@ export const EthereumProvider: React.FC<{}> = ({ children }) => {
           value: byteCode.slice(i + 2, i + 2 + count),
         })
         i += count
+      } else if (
+        selectedFork?.name === mergeHardforkName &&
+        opcode.fullName === 'DIFFICULTY'
+      ) {
+        instructions.push({
+          id,
+          name: 'PREVRANDAO',
+        })
       } else {
         instructions.push({
           id,


### PR DESCRIPTION
Closes #219

Not sure if the hardcoded equality check on `selectedFork.name` is the safest way to do this because this check will need to grow with each future fork. I just copied it from the `extractDocFromOpcode` function in the same file (more info in #219). 