### PR TITLE
chore: update SHA2-256 precompile example output 

### DIFF
--- a/docs/precompiled/0x02.mdx
+++ b/docs/precompiled/0x02.mdx
@@ -20,6 +20,6 @@ fork: Frontier
 
 | Input | Output |
 |------:|-------:|
-| `0xFF` | TODO code is failing |
+| `0xFF` | `a8100ae6aa1940d0b663bb31cd466142ebbdbd5187131b92d93818987832eb89` |
 
 [Reproduce in playground](/playground?unit=Wei&codeType=Mnemonic&code='wFirsWplaceqparameters%20in%20memorybFFjdata~0vMSTOREvvwDoqcallZSizeZ_1XSizeb1FX_2jaddressY4%200xFFFFFFFFjgasvSTATICCALLvvwPutqresulWalonVonqstackvPOPb20vMLOAD'~Y1j%2F%2F%20v%5Cnq%20thVj%20wb~0x_Offset~Zb20jretYvPUSHXjargsWt%20Ve%20%01VWXYZ_bjqvw~_).


### PR DESCRIPTION
The "Reproduce in playground" example on this page runs successfully now, so this PR updates the output to match the playground.

I confirmed the hash from the playground is accurate by running this JavaScript:

```javascript
const input = 0xff;
[...new Uint8Array(await globalThis.crypto.subtle.digest('SHA-256', new Uint8Array([input])))].map(b => b.toString(16).padStart(2, '0')).join('');
// 'a8100ae6aa1940d0b663bb31cd466142ebbdbd5187131b92d93818987832eb89'
```

Note: sometimes the examples prefix the hex with `0x` (like in ecRecover), sometimes not (like in RIPEMD-160). I chose to omit the prefix to be consistent with RIPEMD-160.