### PR TITLE
chore: add blake2f example

### DIFF
--- a/docs/precompiled/0x09.mdx
+++ b/docs/precompiled/0x09.mdx
@@ -19,3 +19,15 @@ fork: Istanbul
 | `[0; 63]` (64 bytes) | h | State vector (8 8-byte little-endian unsigned integer) |
 
 If the input is not valid, or if not enough gas was given, then there is no return data.
+
+## Example
+
+| Input | Output |
+|------:|-------:|
+| `0x0000000c` | `0xba80a53f981c4d0d6a2797b69f12f6e94c212f14685ac4b74b12bb6fdbffa2d17d87c5392aab792dc252d5de4533cc9518d38aa8dbf1925ab92386edd4009923` |
+| `0x48c9bdf267e6096a3ba7ca8485ae67bb2bf894fe72f36e3cf1361d5f3af54fa5d182e6ad7f520e511f6c3e2b8c68059b6bbd41fbabd9831f79217e1319cde05b` | |
+| `0x6162630000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000` | |
+| `0x03000000000000000000000000000000` | |
+| `0x01` | |
+
+[Reproduce in playground](</playground?unit=Wei&codeType=Mnemonic&code='yExecuteBest%20vector%205%20from%20https%3AKeips.Ghereum.org%2FEIPS%2Feip-152XroundJ12~3DhZ48c9bdf267e6096a3ba7ca8485ae67bb2bf894fe72f36e3cf1361d5f3af54fa5~4jZd182e6ad7f520e511f6c3e2b8c68059b6bbd41fbabd9831f79217e1319cde05b~36jXmZ616263))))*~68jXt~3~196Df~1~212DCallW(rGS!rGOVQargsSize~0_argsOV~9_addresJ0xFFFFFFFF_gaswSTATICCALLXRGurnBhe%20result%20ofWwPOP(s!oVwRETURN'~Y1_K%20w%5Cnq***0jwMSTORE_%20yZY32%200xYwPUSHXwwyW%20blake2fVffsGQ~213_K%2F%2FJsY4%20GetDj8XB%20t*00)qq(~64_!izeQ%01!()*BDGJKQVWXYZ_jqwy~_>)


### PR DESCRIPTION
This PR adds a minimal opcode example for the blake2f precompile. The input data was copied from "test vector 5" on https://eips.ethereum.org/EIPS/eip-152