### PR TITLE
fix: shanghai dynamic fee is not displayed

### DIFF
--- a/context/ethereumContext.tsx
+++ b/context/ethereumContext.tsx
@@ -24,7 +24,7 @@ import {
   IChain,
 } from 'types'
 
-import { CURRENT_FORK } from 'util/constants'
+import { CURRENT_FORK, FORKS_WITH_TIMESTAMPS } from 'util/constants'
 import {
   calculateOpcodeDynamicFee,
   calculatePrecompiledDynamicFee,
@@ -423,13 +423,20 @@ export const EthereumProvider: React.FC<{}> = ({ children }) => {
     let currentForkFound = false
 
     common.hardforks().forEach((fork) => {
-      // ignore null block forks
-      if (
-        fork.block ||
-        fork.name === mergeHardforkName ||
-        fork.name === CURRENT_FORK // Hack for Shanghai the timestamp is not set yet
-      ) {
-        forks.push(fork)
+      // FIXME: After shanghai, timestamps are used, so support them in addition
+      // to blocks, and in the meantime use timestamp as the block num.
+      const hasTimestamp = Object.keys(FORKS_WITH_TIMESTAMPS).includes(
+        fork.name,
+      )
+      if (fork.block || hasTimestamp) {
+        if (hasTimestamp) {
+          forks.push({
+            ...fork,
+            block: FORKS_WITH_TIMESTAMPS[fork.name],
+          })
+        } else {
+          forks.push(fork)
+        }
 
         // set initially selected fork
         if (!currentForkFound && fork.name === CURRENT_FORK) {

--- a/util/constants.ts
+++ b/util/constants.ts
@@ -3,3 +3,7 @@ export const GITHUB_REPO_URL = 'https://github.com/smlxlio/evm.codes'
 // Currently active hardfork from the ones available:
 // See: https://github.com/ethereumjs/ethereumjs-monorepo/tree/master/packages/common/src/hardforks
 export const CURRENT_FORK = 'shanghai'
+
+export const FORKS_WITH_TIMESTAMPS: { [name: string]: number } = {
+  shanghai: 1681338455,
+}


### PR DESCRIPTION
as we recently moved to timestamps (shanghai), while the app relies on blocks, the `findMatchingForkName` used in dynamic fee docs fails.

this is a workaround hack to treat timestamp as block numbers until we get ethereumjs packages upgraded and the app working with timestamps.

to be addressed in #238